### PR TITLE
Move HTML to template file

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -40,11 +40,12 @@ class listener implements EventSubscriberInterface
         {
             $user->add_lang_ext('HeatWare/integration', 'common');
 
-            $feedback = $user->lang('HEATWARE_FEEDBACK_PREFIX') . ' ';
+            $post_row = $event['post_row'];
+            $post_row['HEATWARE_FEEDBACK_PREFIX'] = $user->lang('HEATWARE_FEEDBACK_PREFIX');
 
             if ( $event['user_poster_data']['heatware_id'] > 0 && ($config['heatware_global_enable'] || $event['user_poster_data']['heatware_enabled']) )
             {
-                $feedback .= '<a href="https://www.heatware.com/u/' . $event['user_poster_data']['heatware_id'] . '">';
+                $post_row['HEATWARE_ID'] = $event['user_poster_data']['heatware_id'];
                 if( $event['user_poster_data']['heatware_suspended'] == '1' )
                 {
                     $feedback .= $user->lang('HEATWARE_SUSPENDED');
@@ -55,15 +56,12 @@ class listener implements EventSubscriberInterface
                                 $event['user_poster_data']['heatware_negative'] . '-' .
                                 $event['user_poster_data']['heatware_neutral'];
                 }
-
-                $feedback .= '</a>';
             }
             else
             {
                 $feedback .= $user->lang('HEATWARE_NOT_AVAILABLE');
             }
 
-            $post_row = $event['post_row'];
             $post_row['HEATWARE_FEEDBACK'] = $feedback;
             $event['post_row'] = $post_row;
         }

--- a/styles/all/template/event/viewtopic_body_contact_fields_after.html
+++ b/styles/all/template/event/viewtopic_body_contact_fields_after.html
@@ -1,1 +1,1 @@
-<dd class="heatware-feedback">{postrow.HEATWARE_FEEDBACK}</dd>
+<dd class="heatware-feedback">{postrow.HEATWARE_FEEDBACK_PREFIX} <a href="https://www.heatware.com/u/{postrow.HEATWARE_ID}">{postrow.HEATWARE_FEEDBACK}</a></dd>


### PR DESCRIPTION
Fixes #38 by moving the <a href=... HTML to the template file. With that it also changes how the HeatWare ID and the feedback prefix are added by creating spots for them in the template instead of doing string concatenations in the PHP code.