### PR TITLE
Remove unnecessary language assignments by taking advantage of phpBB behavior

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -38,13 +38,8 @@ class main_module
 
 		$template->assign_vars(array(
 			'U_ACTION'                  => $this->u_action,
-            'L_HEATWARE_API_KEY'        => $user->lang('HEATWARE_API_KEY_SETTING'),
 			'S_HEATWARE_API_KEY'		=> $config['heatware_api_key'],
-            'L_HEATWARE_SYNC_FREQUENCY' => $user->lang('HEATWARE_SYNC_SETTING'),
 			'S_HEATWARE_SYNC_FREQUENCY' => $config['heatware_sync_frequency'],
-			'L_HEATWARE_SYNC_DESC'		=> $user->lang('HEATWARE_SYNC_DESC'),
-            'L_HEATWARE_GLOBAL_ENABLE' 	=> $user->lang('HEATWARE_GLOBAL_SETTING'),
-			'L_HEATWARE_GLOBAL_DESC'	=> $user->lang('HEATWARE_GLOBAL_DESC'),
             'S_HEATWARE_GLOBAL_ENABLE' 	=> $config['heatware_global_enable'],
 		));
 	}

--- a/language/en/info_acp_lang.php
+++ b/language/en/info_acp_lang.php
@@ -12,10 +12,10 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, array(
 	'HEATWARE_FORCE_BADGE'		      => 'Enable badge for all users',
-	'HEATWARE_API_KEY_SETTING'        => 'API Key',
-	'HEATWARE_SYNC_SETTING'		      => 'Feedback synchronization frequency',
+	'HEATWARE_API_KEY'                => 'API Key',
+	'HEATWARE_SYNC_FREQUENCY'		  => 'Feedback synchronization frequency',
 	'HEATWARE_SYNC_DESC'		      => 'Time in seconds, min: 3600',
-	'HEATWARE_GLOBAL_SETTING'	      => 'Enable feedback badges for all users',
+	'HEATWARE_GLOBAL_ENABLE'	      => 'Enable feedback badges for all users',
 	'HEATWARE_GLOBAL_DESC'		      => 'Checked: Enable feedback badge for all users. Unchecked: Lets users decide for themselves.',
 	'HEATWARE_INTEGRATION_SETTING'    => 'Integration Settings',
 ));

--- a/language/en/info_ucp_lang.php
+++ b/language/en/info_ucp_lang.php
@@ -11,7 +11,7 @@ if (empty($lang) || !is_array($lang))
 }
 
 $lang = array_merge($lang, array(
-	'HEATWARE_SHOW_BADGE_SETTING'	=> 'Show my HeatWare badge',
+	'HEATWARE_SHOW_BADGE'       	=> 'Show my HeatWare badge',
 	'HEATWARE_GLOBAL_ENABLED'		=> 'NOTE: The forum administrators have globally enabled HeatWare feedback. Changing this setting will make no difference.',
 	'HEATWARE_USER_SETTING'         => 'User Settings',
 ));

--- a/ucp/main_module.php
+++ b/ucp/main_module.php
@@ -37,9 +37,7 @@ class main_module
 		}
 
 		$template->assign_vars(array(
-			'L_HEATWARE_SHOW_BADGE'	=> $user->lang('HEATWARE_SHOW_BADGE_SETTING'),
 			'S_HEATWARE_SHOW_BADGE'	=> $user->data['heatware_enabled'],
-			'L_HEATWARE_GLOBAL_ENABLED' => $user->lang('HEATWARE_GLOBAL_ENABLED'),
 			'S_HEATWARE_GLOBAL_ENABLED' => $config['heatware_global_enable'],
 			'S_UCP_ACTION'	=> $this->u_action,
 		));


### PR DESCRIPTION
Fixes #36 

https://wiki.phpbb.com/Tutorial.Template_syntax#Variables_2

Templates will already tried to auto assign anything that follows the format L_XXXX. This updates the code to take advantage of that.