### PR TITLE
Fixes references to old camel case namespace

### DIFF
--- a/acp/main_info.php
+++ b/acp/main_info.php
@@ -7,7 +7,7 @@ class main_info
 	function module()
 	{
 		return array(
-			'filename'	=> '\HeatWare\integration\acp\main_module',
+			'filename'	=> '\heatware\integration\acp\main_module',
 			'title'		=> $user->lang('HEATWARE_TITLE'),
 			'modes'		=> array(
 				'settings'	=> array(

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,6 +1,6 @@
 services:
     HeatWare.integration.cron.task.HeatWareSync:
-        class: HeatWare\integration\cron\task\HeatWareSync
+        class: heatware\integration\cron\task\HeatWareSync
         arguments:
             - '@config'
             - '@dbal.conn'
@@ -12,6 +12,6 @@ services:
             - { name: cron.task }
 
     HeatWare.integration.listener:
-        class: HeatWare\integration\event\listener
+        class: heatware\integration\event\listener
         tags:
             - { name: event.listener }

--- a/migrations/install_acp_module.php
+++ b/migrations/install_acp_module.php
@@ -32,7 +32,7 @@ class install_acp_module extends \phpbb\db\migration\migration
 				'acp',
 				'HeatWare',
 				array(
-					'module_basename'	=> '\HeatWare\integration\acp\main_module',
+					'module_basename'	=> '\heatware\integration\acp\main_module',
 					'modes'				=> array('settings'),
 				),
 			)),

--- a/migrations/install_ucp_module.php
+++ b/migrations/install_ucp_module.php
@@ -19,7 +19,7 @@ class install_ucp_module extends \phpbb\db\migration\migration
 
 	static public function depends_on()
 	{
-		return array('\HeatWare\integration\migrations\install_user_schema');
+		return array('\heatware\integration\migrations\install_user_schema');
 	}
 
 	public function update_data()
@@ -34,7 +34,7 @@ class install_ucp_module extends \phpbb\db\migration\migration
 				'ucp',
 				'HeatWare',
 				array(
-					'module_basename'	=> '\HeatWare\integration\ucp\main_module',
+					'module_basename'	=> '\heatware\integration\ucp\main_module',
 					'modes'				=> array('settings'),
 				),
 			)),

--- a/ucp/main_info.php
+++ b/ucp/main_info.php
@@ -7,7 +7,7 @@ class main_info
 	function module()
 	{
 		return array(
-			'filename'	=> '\HeatWare\integration\ucp\main_module',
+			'filename'	=> '\heatware\integration\ucp\main_module',
 			'title'		=> $user->lang('HEATWARE_TITLE'),
 			'modes'		=> array(
 				'settings'	=> array(

--- a/ucp/main_module.php
+++ b/ucp/main_module.php
@@ -10,7 +10,7 @@ class main_module
 	{
 		global $db, $request, $template, $user, $config;
 
-		$user->add_lang_ext('HeatWare/integration', 'common');
+		$user->add_lang_ext('heatware/integration', 'common');
 		$this->tpl_name = 'ucp_body';
 		$this->page_title = $user->lang('HEATWARE_SETTINGS_TITLE');
 		add_form_key('heatware/integration');


### PR DESCRIPTION
Fixes #45 and fixes any remaining references to the old namespace that used HeatWare instead of heatware.