### PR TITLE
Fixes for main_info.php files, more forgotten camel case conversions, increase date

### DIFF
--- a/acp/main_info.php
+++ b/acp/main_info.php
@@ -8,12 +8,12 @@ class main_info
 	{
 		return array(
 			'filename'	=> '\heatware\integration\acp\main_module',
-			'title'		=> $user->lang('HEATWARE_TITLE'),
+			'title'		=> 'HEATWARE_TITLE',
 			'modes'		=> array(
 				'settings'	=> array(
-					'title'	=> $user->lang('HEATWARE_INTEGRATION_SETTING'),
-					'auth'	=> 'ext_HeatWare/integration && acl_a_board',
-					'cat'	=> array($user->lang('HEATWARE_TITLE'))
+					'title'	=> 'HEATWARE_INTEGRATION_SETTING',
+					'auth'	=> 'ext_heatware/integration && acl_a_board',
+					'cat'	=> array('HEATWARE_TITLE'),
 				),
 			),
 		);

--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -10,14 +10,14 @@ class main_module
 	{
 		global $config, $request, $template, $user;
 
-		$user->add_lang_ext('HeatWare/integration', 'common');
+		$user->add_lang_ext('heatware/integration', 'common');
 		$this->tpl_name = 'acp_body';
 		$this->page_title = $user->lang('HEATWARE_SETTINGS_TITLE');
 		add_form_key('HeatWare/integration');
 
 		if ($request->is_set_post('submit'))
 		{
-			if (!check_form_key('HeatWare/integration'))
+			if (!check_form_key('heatware/integration'))
 			{
 				trigger_error('FORM_INVALID');
 			}

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "HeatWare/integration",
+    "name": "heatware/integration",
     "type": "phpbb-extension",
     "description": "",
     "homepage": "https://github.com/heatware/phpbb-global-feedback-plugin/",
     "version": "1.0.0",
-    "time": "2016-04-28",
+    "time": "2016-11-06",
     "license": "GPL-2.0",
     "authors": [
         {

--- a/event/listener.php
+++ b/event/listener.php
@@ -38,7 +38,7 @@ class listener implements EventSubscriberInterface
         
         if ($event['row']['user_id'] != ANONYMOUS)
         {
-            $user->add_lang_ext('HeatWare/integration', 'common');
+            $user->add_lang_ext('heatware/integration', 'common');
 
             $post_row = $event['post_row'];
             $post_row['HEATWARE_FEEDBACK_PREFIX'] = $user->lang('HEATWARE_FEEDBACK_PREFIX');

--- a/ucp/main_info.php
+++ b/ucp/main_info.php
@@ -8,12 +8,12 @@ class main_info
 	{
 		return array(
 			'filename'	=> '\heatware\integration\ucp\main_module',
-			'title'		=> $user->lang('HEATWARE_TITLE'),
+			'title'		=> 'HEATWARE_TITLE',
 			'modes'		=> array(
 				'settings'	=> array(
-					'title'	=> $user->lang('HEATWARE_USER_SETTING'),
-					'auth'	=> 'ext_HeatWare/integration',
-					'cat'	=> array($user->lang('HEATWARE_TITLE'))
+					'title'	=> 'HEATWARE_USER_SETTING',
+					'auth'	=> 'ext_heatware/integration',
+					'cat'	=> array('HEATWARE_TITLE'),
 				),
 			),
 		);


### PR DESCRIPTION
Lots of little changes. Fixes errors in the main_info.php files that cause language issues. Couple of forgotten cases where HeatWare needed to convert to heatware. Also increased the data to today since there will be a new packaging of this release and the date should be accurate.